### PR TITLE
Cached data dumps

### DIFF
--- a/src/crates_cache.rs
+++ b/src/crates_cache.rs
@@ -112,7 +112,11 @@ impl CratesCache {
     }
 
     /// Re-download the list from the data dumps.
-    pub fn download(&mut self, client: &mut RateLimitedClient, max_age: std::time::Duration) -> io::Result<DownloadState> {
+    pub fn download(
+        &mut self,
+        client: &mut RateLimitedClient,
+        max_age: std::time::Duration,
+    ) -> io::Result<DownloadState> {
         let cache = self.cache_dir.as_ref().ok_or(io::ErrorKind::NotFound)?;
         cache.validate_file_creation()?;
 
@@ -135,7 +139,7 @@ impl CratesCache {
 
         // Not modified.
         if response.status() == 304 {
-            return Ok(DownloadState::Fresh)
+            return Ok(DownloadState::Fresh);
         }
 
         let etag = response.header("etag").map(String::from);
@@ -180,10 +184,14 @@ impl CratesCache {
                     )?;
                 } else if entry.path_bytes().ends_with(b"metadata.json") {
                     let meta: Metadata = serde_json::from_reader(entry)?;
-                    cache.store(&mut self.metadata, Self::METADATA_FS, MetadataStored {
-                        timestamp: meta.timestamp,
-                        etag: etag.clone(),
-                    })?;
+                    cache.store(
+                        &mut self.metadata,
+                        Self::METADATA_FS,
+                        MetadataStored {
+                            timestamp: meta.timestamp,
+                            etag: etag.clone(),
+                        },
+                    )?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ fn eprint_help() {
     authors\t\tList all authors in the dependency graph (as specified in Cargo.toml)
     publishers\t\tList all crates.io publishers in the dependency graph
     crates\t\tList all crates in dependency graph and crates.io publishers for each
+    update\t\tDownload the latest daily dump from crates.io to speed up other commands
 
   Any arguments after -- will be passed to `cargo metadata`, for example:
     cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu

--- a/src/subcommands/update.rs
+++ b/src/subcommands/update.rs
@@ -1,6 +1,6 @@
 use crate::api_client::RateLimitedClient;
 use crate::common::*;
-use crate::crates_cache::CratesCache;
+use crate::crates_cache::{CratesCache, DownloadState};
 
 pub fn update(mut args: std::env::ArgsOs) {
     if let Some(arg) = args.next() {
@@ -9,5 +9,8 @@ pub fn update(mut args: std::env::ArgsOs) {
 
     let mut cache = CratesCache::new();
     let mut client = RateLimitedClient::new();
-    cache.download(&mut client).unwrap();
+    match cache.download(&mut client).unwrap() {
+        DownloadState::Fresh => println!("No updates found"),
+        DownloadState::Expired => println!("Successfully updated to the newest daily data dump."),
+    }
 }

--- a/src/subcommands/update.rs
+++ b/src/subcommands/update.rs
@@ -16,6 +16,6 @@ pub fn update(mut args: std::env::ArgsOs) {
         DownloadState::Stale => {
             println!("Downloaded latest daily data dump.");
             println!("  Warning: it matches the previous version that was considered outdated.");
-        },
+        }
     }
 }

--- a/src/subcommands/update.rs
+++ b/src/subcommands/update.rs
@@ -9,8 +9,13 @@ pub fn update(mut args: std::env::ArgsOs) {
 
     let mut cache = CratesCache::new();
     let mut client = RateLimitedClient::new();
-    match cache.download(&mut client).unwrap() {
+    let stale = std::time::Duration::from_secs(48 * 3600);
+    match cache.download(&mut client, stale).unwrap() {
         DownloadState::Fresh => println!("No updates found"),
         DownloadState::Expired => println!("Successfully updated to the newest daily data dump."),
+        DownloadState::Stale => {
+            println!("Downloaded latest daily data dump.");
+            println!("  Warning: it matches the previous version that was considered outdated.");
+        },
     }
 }


### PR DESCRIPTION
Store the E-Tag sent by crates.io to avoid a download of data which we already have.