### PR TITLE
Handle invalid arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,12 +101,14 @@ fn args_parser() -> Result<Args, pico_args::Error> {
         };
         if !args.free.is_empty() {
             eprint_help();
-            panic!("Failed to parse arguments");
+            return Err(pico_args::Error::UnusedArgsLeft(args.free));
         }
         Ok(args)
     } else {
         eprint_help();
-        panic!("Failed to parse arguments");
+        Err(pico_args::Error::ArgumentParsingFailed {
+            cause: "No subcommand given".to_string(),
+        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ struct Args {
     command: String,
     cache_max_age: Duration,
     metadata_args: Vec<String>,
+    free: Vec<String>,
 }
 
 fn main() {
@@ -96,7 +97,12 @@ fn args_parser() -> Result<Args, pico_args::Error> {
             cache_max_age: args
                 .opt_value_from_fn("--cache-max-age", parse_max_age)?
                 .unwrap_or(default_cache_max_age),
+            free: args.free()?,
         };
+        if !args.free.is_empty() {
+            eprint_help();
+            panic!("Failed to parse arguments");
+        }
         Ok(args)
     } else {
         eprint_help();


### PR DESCRIPTION
It seems the call to free() is required to make sure we don't get any extra arguments we don't expect.

With this code I get this instead:
```
./target/debug/cargo-supply-chain crates --blargh
Error: unused arguments left: --blargh
Usage: cargo supply-chain COMMA..
```