### PR TITLE
Fixed bug with supply_args filtering for cargo arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,10 @@ fn get_grouped_args() -> (Vec<OsString>, Vec<String>) {
     // When invoked via `cargo supply-chain update`, Cargo passes the arguments it receives verbatim.
     // So instead of "update" our binary receives "supply-chain update".
     // We ignore the "supply-chain" in the beginning if it's present.
-    if supply_args[0] == "supply-chain" {
+    if supply_args.get(0) == Some(&OsString::from("supply-chain")) {
         supply_args.remove(0);
     }
+
     (supply_args, metadata_args)
 }
 


### PR DESCRIPTION
Before this commit I was getting the following error:

```none
    Finished dev [unoptimized + debuginfo] target(s) in 1m 07s
     Running `target/debug/cargo-supply-chain`
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', src/main.rs:80:8
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Context is this statement:

```rust
// When invoked via `cargo supply-chain update`, Cargo passes the arguments it receives verbatim.
// So instead of "update" our binary receives "supply-chain update".
// We ignore the "supply-chain" in the beginning if it's present.
if supply_args[0] == "supply-chain" {
    supply_args.remove(0);
}
```

After a simple `cargo run` of this crate. I fixed the bounds error which may have been caused by pico-args not always returning the first argument as the caller