### PR TITLE
Better CLI help formatting with em dashes to simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Run `cargo install cargo-supply-chain` to install this tool. Once installed, sim
 - `publishers` - Lists all the people and teams that can publish updates to your dependencies on crates.io.
 - `crates` - Lists all the crates you depend on, with the list of publishers for each crate.
 - `update` - Downloads a daily database dump of crates.io (roughly 256Mb) to speed up `publishers` and `crates` subcommands. Data downloaded this way may be out of date by up to 48 hours. You can set the maximum allowed age using the `--cache-max-age` flag; if it's exceeded, live data will be fetched instead.
+- `help` - Displays this help message and exits.
 
 ### Filtering
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,18 +114,18 @@ fn eprint_help() {
     eprintln!(
         "Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]
 
-  Commands:
-    authors — List all authors in the dependency graph (as specified in Cargo.toml)
-    publishers — List all crates.io publishers in the dependency graph
-    crates — List all crates in dependency graph and crates.io publishers for each
-    update — Download the latest daily dump from crates.io to speed up other commands
+Commands:
+  authors — List all authors in the dependency graph (as specified in Cargo.toml)
+  publishers — List all crates.io publishers in the dependency graph
+  crates — List all crates in dependency graph and crates.io publishers for each
+  update — Download the latest daily dump from crates.io to speed up other commands
 
-  Arguments:
-    --cache-max-age — The cache will be considered valid while younger than specified.
-                      The format is a human readable duration such as `1w` or `1d 6h`.
+Arguments:
+  --cache-max-age — The cache will be considered valid while younger than specified.
+                    The format is a human readable duration such as `1w` or `1d 6h`.
 
-  Any arguments after the `--` will be passed to `cargo metadata`, for example:
-    cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
+Any arguments after the `--` will be passed to `cargo metadata`, for example:
+  cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
 "
     );
     std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,15 +115,16 @@ fn eprint_help() {
         "Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]
 
   Commands:
-    authors\t\tList all authors in the dependency graph (as specified in Cargo.toml)
-    publishers\t\tList all crates.io publishers in the dependency graph
-    crates\t\tList all crates in dependency graph and crates.io publishers for each
-    update\t\tDownload the latest daily dump from crates.io to speed up other commands
-  Arguments:
-    --cache-max-age\t\tThe cache will be considered valid while younger than specified.
-    \t\t\tThe format is a human recognizable duration such as `1w` or `1d 6h`.
+    authors — List all authors in the dependency graph (as specified in Cargo.toml)
+    publishers — List all crates.io publishers in the dependency graph
+    crates — List all crates in dependency graph and crates.io publishers for each
+    update — Download the latest daily dump from crates.io to speed up other commands
 
-  Any arguments after -- will be passed to `cargo metadata`, for example:
+  Arguments:
+    --cache-max-age — The cache will be considered valid while younger than specified.
+                      The format is a human readable duration such as `1w` or `1d 6h`.
+
+  Any arguments after the `--` will be passed to `cargo metadata`, for example:
     cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
 "
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,24 @@ mod crates_cache;
 mod publishers;
 mod subcommands;
 
+/// CLI-focused help message for displaying to the user
+pub(crate) const CLI_HELP: &str =
+    "Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]
+
+Commands:
+  authors — List all authors in the dependency graph (as specified in Cargo.toml)
+  publishers — List all crates.io publishers in the dependency graph
+  crates — List all crates in dependency graph and crates.io publishers for each
+  update — Download the latest daily dump from crates.io to speed up other commands
+  help — Displays this help message and exits
+
+Arguments:
+  --cache-max-age — The cache will be considered valid while younger than specified.
+                    The format is a human readable duration such as `1w` or `1d 6h`.
+
+Any arguments after the `--` will be passed to `cargo metadata`, for example:
+  cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu";
+
 #[derive(Debug)]
 struct Args {
     help: bool,
@@ -53,6 +71,7 @@ fn handle_args(args: Args) -> Result<(), std::io::Error> {
         "publishers" => subcommands::publishers(args.metadata_args, args.cache_max_age)?,
         "crates" => subcommands::crates(args.metadata_args, args.cache_max_age)?,
         "update" => subcommands::update(args.cache_max_age),
+        "help" => subcommands::help(),
         _ => eprint_help(),
     }
     Ok(())
@@ -111,22 +130,6 @@ fn args_parser() -> Result<Args, pico_args::Error> {
 }
 
 fn eprint_help() {
-    eprintln!(
-        "Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]
-
-Commands:
-  authors — List all authors in the dependency graph (as specified in Cargo.toml)
-  publishers — List all crates.io publishers in the dependency graph
-  crates — List all crates in dependency graph and crates.io publishers for each
-  update — Download the latest daily dump from crates.io to speed up other commands
-
-Arguments:
-  --cache-max-age — The cache will be considered valid while younger than specified.
-                    The format is a human readable duration such as `1w` or `1d 6h`.
-
-Any arguments after the `--` will be passed to `cargo metadata`, for example:
-  cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
-"
-    );
+    eprintln!("{}", CLI_HELP);
     std::process::exit(1);
 }

--- a/src/subcommands/help.rs
+++ b/src/subcommands/help.rs
@@ -1,0 +1,10 @@
+//! Displays help infomation to the user when requested
+
+use crate::CLI_HELP;
+use std::process;
+
+/// Provides help infomation which proceeds to exit
+pub fn help() {
+    println!("{}", CLI_HELP);
+    process::exit(0)
+}

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -1,9 +1,11 @@
 pub mod authors;
 pub mod crates;
+pub mod help;
 pub mod publishers;
 pub mod update;
 
 pub use authors::authors;
 pub use crates::crates;
+pub use help::help;
 pub use publishers::publishers;
 pub use update::update;


### PR DESCRIPTION
Simplified the projection of the CLI help message from:

```none
Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]

  Commands:
    authors             List all authors in the dependency graph (as specified in Cargo.toml)
    publishers          List all crates.io publishers in the dependency graph
    crates              List all crates in dependency graph and crates.io publishers for each
    update              Download the latest daily dump from crates.io to speed up other commands
  Arguments:
    --cache-max-age             The cache will be considered valid while younger than specified.
                        The format is a human recognizable duration such as `1w` or `1d 6h`.

  Any arguments after -- will be passed to `cargo metadata`, for example:
    cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
```

To the following:

```none
Usage: cargo supply-chain COMMAND [OPTIONS...] [-- CARGO_METADATA_OPTIONS...]

Commands:
  authors — List all authors in the dependency graph (as specified in Cargo.toml)
  publishers — List all crates.io publishers in the dependency graph
  crates — List all crates in dependency graph and crates.io publishers for each
  update — Download the latest daily dump from crates.io to speed up other commands
  help — Displays this help message and exits

Arguments:
  --cache-max-age — The cache will be considered valid while younger than specified.
                    The format is a human readable duration such as `1w` or `1d 6h`.

Any arguments after the `--` will be passed to `cargo metadata`, for example:
  cargo supply-chain crates -- --filter-platform=x86_64-unknown-linux-gnu
```