### PR TITLE
Update to ureq2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,15 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,15 +573,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.5.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
+checksum = "96014ded8c85822677daee4f909d18acccca744810fd4f8ffc492c284f2324bc"
 dependencies = [
  "base64",
  "chunked_transfer",
  "log",
  "once_cell",
- "qstring",
  "rustls",
  "rustls-native-certs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ directories-next = "2"
 flate2 = "1"
 humantime = "2"
 humantime-serde = "1"
-ureq = {version = "1.5.0", default-features=false, features = ["tls", "native-certs", "json"]}
+ureq = { version = "2.0.1", default-features=false, features = ["tls", "native-certs", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.30"

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -9,13 +9,7 @@ impl Default for RateLimitedClient {
     fn default() -> Self {
         RateLimitedClient {
             last_request_time: None,
-            agent: ureq::agent()
-                .set(
-                    "User-Agent",
-                    "cargo supply-chain (https://github.com/rust-secure-code/cargo-supply-chain)",
-                )
-                .set("Accept", "application/json")
-                .build(),
+            agent: ureq::agent(),
         }
     }
 }
@@ -27,7 +21,10 @@ impl RateLimitedClient {
 
     pub fn get(&mut self, url: &str) -> ureq::Request {
         self.wait_to_honor_rate_limit();
-        self.agent.get(url)
+        self.agent.get(url).set(
+            "User-Agent",
+            "cargo supply-chain (https://github.com/rust-secure-code/cargo-supply-chain)",
+        )
     }
 
     /// Waits until at least 1 second has elapsed since last request,


### PR DESCRIPTION
Fixes #39

Also unified the usage of `io::{Error, Result}` to match the latest(?) style of module prefixing I found in `main.rs` 