### PR TITLE
Diff-friendly output mode

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -12,10 +12,10 @@ pub struct SourcedPackage {
     pub package: Package,
 }
 
-pub fn sourced_dependencies(extra_options: Vec<String>) -> Vec<SourcedPackage> {
+pub fn sourced_dependencies(metadata_args: Vec<String>) -> Vec<SourcedPackage> {
     let meta = MetadataCommand::new()
         .features(AllFeatures)
-        .other_options(extra_options)
+        .other_options(metadata_args)
         .exec()
         .unwrap();
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -75,11 +75,11 @@ pub fn complain_about_non_crates_io_crates(dependencies: &[SourcedPackage]) {
         // scope bound to avoid accidentally referencing local crates when working with foreign ones
         let local_crate_names = crate_names_from_source(dependencies, PkgSource::Local);
         if !local_crate_names.is_empty() {
-            println!(
+            eprintln!(
                 "\nThe following crates will be ignored because they come from a local directory:"
             );
             for crate_name in &local_crate_names {
-                println!(" - {}", crate_name);
+                eprintln!(" - {}", crate_name);
             }
         }
     }
@@ -87,9 +87,9 @@ pub fn complain_about_non_crates_io_crates(dependencies: &[SourcedPackage]) {
     {
         let foreign_crate_names = crate_names_from_source(dependencies, PkgSource::Foreign);
         if !foreign_crate_names.is_empty() {
-            println!("\nCannot audit the following crates because they are not from crates.io:");
+            eprintln!("\nCannot audit the following crates because they are not from crates.io:");
             for crate_name in &foreign_crate_names {
-                println!(" - {}", crate_name);
+                eprintln!(" - {}", crate_name);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ See `cargo metadata --help` for a list of flags it supports.";
 struct Args {
     help: bool,
     command: String,
+    diffable: bool,
     cache_max_age: Duration,
     metadata_args: Vec<String>,
     free: Vec<String>,
@@ -75,9 +76,9 @@ fn dispatch_command(args: Args) -> Result<(), std::io::Error> {
             eprint_help();
         }
         match args.command.as_str() {
-            "publishers" => subcommands::publishers(args.metadata_args, args.cache_max_age)?,
-            "crates" => subcommands::crates(args.metadata_args, args.cache_max_age)?,
-            "json" => subcommands::json(args.metadata_args, args.cache_max_age)?,
+            "publishers" => subcommands::publishers(args.metadata_args, args.diffable, args.cache_max_age)?,
+            "crates" => subcommands::crates(args.metadata_args, args.diffable, args.cache_max_age)?,
+            "json" => subcommands::json(args.metadata_args, args.diffable, args.cache_max_age)?,
             "update" => subcommands::update(args.cache_max_age),
             "help" => subcommands::help(args.free.get(0).map(String::as_str)),
             _ => eprint_help(),
@@ -122,6 +123,7 @@ fn parse_args() -> Result<Args, pico_args::Error> {
         let args = Args {
             help: args.contains(["-h", "--help"]),
             command,
+            diffable: args.contains(["-d", "--diffable"]),
             metadata_args,
             cache_max_age: args
                 .opt_value_from_fn("--cache-max-age", parse_max_age)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn dispatch_command(args: Args) -> Result<(), std::io::Error> {
             eprint_help();
         }
         match args.command.as_str() {
-            "publishers" => subcommands::publishers(args.metadata_args, args.diffable, args.cache_max_age)?,
+            "publishers" => {
+                subcommands::publishers(args.metadata_args, args.diffable, args.cache_max_age)?
+            }
             "crates" => subcommands::crates(args.metadata_args, args.diffable, args.cache_max_age)?,
             "json" => subcommands::json(args.metadata_args, args.diffable, args.cache_max_age)?,
             "update" => subcommands::update(args.cache_max_age),

--- a/src/subcommands/crates.rs
+++ b/src/subcommands/crates.rs
@@ -17,7 +17,7 @@ pub fn crates(
     let mut ordered_owners: Vec<_> = owners.into_iter().collect();
     if diffable {
         // Sort alphabetically by crate name
-        ordered_owners.sort_unstable_by_key(|(name, _)| name.clone() );
+        ordered_owners.sort_unstable_by_key(|(name, _)| name.clone());
     } else {
         // Order by the number of owners, but put crates owned by teams first
         ordered_owners.sort_unstable_by_key(|(name, publishers)| {

--- a/src/subcommands/crates.rs
+++ b/src/subcommands/crates.rs
@@ -1,8 +1,12 @@
 use crate::common::*;
 use crate::publishers::{fetch_owners_of_crates, PublisherKind};
 
-pub fn crates(args: Vec<String>, max_age: std::time::Duration) -> Result<(), std::io::Error> {
-    let dependencies = sourced_dependencies(args);
+pub fn crates(
+    metadata_args: Vec<String>,
+    diffable: bool,
+    max_age: std::time::Duration,
+) -> Result<(), std::io::Error> {
+    let dependencies = sourced_dependencies(metadata_args);
     complain_about_non_crates_io_crates(&dependencies);
     let (mut owners, publisher_teams) = fetch_owners_of_crates(&dependencies, max_age)?;
 

--- a/src/subcommands/json.rs
+++ b/src/subcommands/json.rs
@@ -21,7 +21,11 @@ pub struct NotAudited {
     foreign_crates: Vec<String>,
 }
 
-pub fn json(args: Vec<String>, diffable: bool, max_age: std::time::Duration) -> Result<(), std::io::Error> {
+pub fn json(
+    args: Vec<String>,
+    diffable: bool,
+    max_age: std::time::Duration,
+) -> Result<(), std::io::Error> {
     let mut output = StructuredOutput::default();
     let dependencies = sourced_dependencies(args);
     // Report non-crates.io dependencies

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -20,7 +20,14 @@ pub fn publishers(
     user_to_crate_map.values_mut().for_each(|c| c.sort());
     team_to_crate_map.values_mut().for_each(|c| c.sort());
 
-    if !publisher_users.is_empty() && !diffable {
+    if diffable {
+        // empty map just means 0 loop iterations here
+        let sorted_map = sort_transposed_map_for_diffing(user_to_crate_map);
+        for (user, crates) in sorted_map.iter() {
+            let crate_list = comma_separated_list(&crates);
+            println!("user \"{}\": {}", &user.login, crate_list);
+        }
+    } else if !publisher_users.is_empty() {
         println!("\nThe following individuals can publish updates for your dependencies:\n");
         let map_for_display = sort_transposed_map_for_display(user_to_crate_map);
         for (i, (user, crates)) in map_for_display.iter().enumerate() {
@@ -31,16 +38,15 @@ pub fn publishers(
         }
         eprintln!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
         eprintln!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
-    } else if diffable {
-        // empty map just means 0 loop iterations here
-        let sorted_map = sort_transposed_map_for_diffing(user_to_crate_map);
-        for (user, crates) in sorted_map.iter() {
-            let crate_list = comma_separated_list(&crates);
-            println!("user \"{}\": {}", &user.login, crate_list);
-        }
     }
 
-    if !publisher_teams.is_empty() && !diffable {
+    if diffable {
+        let sorted_map = sort_transposed_map_for_diffing(team_to_crate_map);
+        for (team, crates) in sorted_map.iter() {
+            let crate_list = comma_separated_list(&crates);
+            println!("team \"{}\": {}", &team.login, crate_list);
+        }
+    } else if !publisher_teams.is_empty() {
         println!(
             "\nAll members of the following teams can publish updates for your dependencies:\n"
         );
@@ -63,12 +69,6 @@ pub fn publishers(
             }
         }
         eprintln!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
-    } else if diffable {
-        let sorted_map = sort_transposed_map_for_diffing(team_to_crate_map);
-        for (team, crates) in sorted_map.iter() {
-            let crate_list = comma_separated_list(&crates);
-            println!("team \"{}\": {}", &team.login, crate_list);
-        }
     }
     Ok(())
 }

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -31,7 +31,8 @@ pub fn publishers(
         }
         println!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
         println!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
-    } else if diffable { // empty map just means 0 loop iterations here
+    } else if diffable {
+        // empty map just means 0 loop iterations here
         let sorted_map = sort_transposed_map_for_diffing(user_to_crate_map);
         for (user, crates) in sorted_map.iter() {
             let crate_list = comma_separated_list(&crates);
@@ -105,8 +106,6 @@ fn sort_transposed_map_for_diffing(
     input: BTreeMap<PublisherData, Vec<String>>,
 ) -> Vec<(PublisherData, Vec<String>)> {
     let mut result: Vec<_> = input.into_iter().collect();
-    result.sort_unstable_by_key(|(publisher, _crates)| {
-        publisher.login.clone()
-    });
+    result.sort_unstable_by_key(|(publisher, _crates)| publisher.login.clone());
     result
 }

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -29,8 +29,8 @@ pub fn publishers(
             let crate_list = comma_separated_list(&crates);
             println!(" {}. {} via crates: {}", i + 1, &user.login, crate_list);
         }
-        println!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
-        println!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
+        eprintln!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
+        eprintln!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
     } else if diffable {
         // empty map just means 0 loop iterations here
         let sorted_map = sort_transposed_map_for_diffing(user_to_crate_map);
@@ -62,7 +62,7 @@ pub fn publishers(
                 println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
             }
         }
-        println!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
+        eprintln!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
     } else if diffable {
         let sorted_map = sort_transposed_map_for_diffing(team_to_crate_map);
         for (team, crates) in sorted_map.iter() {

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -12,27 +12,37 @@ pub fn publishers(
     complain_about_non_crates_io_crates(&dependencies);
     let (publisher_users, publisher_teams) = fetch_owners_of_crates(&dependencies, max_age)?;
 
-    if !publisher_users.is_empty() {
+    // Group data by user rather than by crate
+    let mut user_to_crate_map = transpose_publishers_map(&publisher_users);
+    let mut team_to_crate_map = transpose_publishers_map(&publisher_teams);
+
+    // Sort crate names alphabetically
+    user_to_crate_map.values_mut().for_each(|c| c.sort());
+    team_to_crate_map.values_mut().for_each(|c| c.sort());
+
+    if !publisher_users.is_empty() && !diffable {
         println!("\nThe following individuals can publish updates for your dependencies:\n");
-        let user_to_crate_map = transpose_publishers_map(&publisher_users);
         let map_for_display = sort_transposed_map_for_display(user_to_crate_map);
         for (i, (user, crates)) in map_for_display.iter().enumerate() {
             // We do not print usernames, since you can embed terminal control sequences in them
             // and erase yourself from the output that way.
-            // TODO: check if it's possible to smuggle those into github/crates.io usernames
             let crate_list = comma_separated_list(&crates);
             println!(" {}. {} via crates: {}", i + 1, &user.login, crate_list);
         }
+        println!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
+        println!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
+    } else if diffable { // empty map just means 0 loop iterations here
+        let sorted_map = sort_transposed_map_for_diffing(user_to_crate_map);
+        for (user, crates) in sorted_map.iter() {
+            let crate_list = comma_separated_list(&crates);
+            println!("user \"{}\": {}", &user.login, crate_list);
+        }
     }
 
-    println!("\nNote: there may be outstanding publisher invitations. crates.io provides no way to list them.");
-    println!("See https://github.com/rust-lang/crates.io/issues/2868 for more info.");
-
-    if !publisher_teams.is_empty() {
+    if !publisher_teams.is_empty() && !diffable {
         println!(
             "\nAll members of the following teams can publish updates for your dependencies:\n"
         );
-        let team_to_crate_map = transpose_publishers_map(&publisher_teams);
         let map_for_display = sort_transposed_map_for_display(team_to_crate_map);
         for (i, (team, crates)) in map_for_display.iter().enumerate() {
             let crate_list = comma_separated_list(&crates);
@@ -52,6 +62,12 @@ pub fn publishers(
             }
         }
         println!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
+    } else if diffable {
+        let sorted_map = sort_transposed_map_for_diffing(team_to_crate_map);
+        for (team, crates) in sorted_map.iter() {
+            let crate_list = comma_separated_list(&crates);
+            println!("team \"{}\": {}", &team.login, crate_list);
+        }
     }
     Ok(())
 }
@@ -75,18 +91,22 @@ fn transpose_publishers_map(
 
 /// Returns a Vec sorted so that publishers are sorted by the number of crates they control.
 /// If that number is the same, sort by login.
-/// Crate names are also sorted.
 fn sort_transposed_map_for_display(
     input: BTreeMap<PublisherData, Vec<String>>,
 ) -> Vec<(PublisherData, Vec<String>)> {
     let mut result: Vec<_> = input.into_iter().collect();
-    // Sort crate names
-    for (_publisher, crates_list) in result.iter_mut() {
-        crates_list.sort_unstable();
-    }
-    // Sort user names
     result.sort_unstable_by_key(|(publisher, crates)| {
         (usize::MAX - crates.len(), publisher.login.clone())
+    });
+    result
+}
+
+fn sort_transposed_map_for_diffing(
+    input: BTreeMap<PublisherData, Vec<String>>,
+) -> Vec<(PublisherData, Vec<String>)> {
+    let mut result: Vec<_> = input.into_iter().collect();
+    result.sort_unstable_by_key(|(publisher, _crates)| {
+        publisher.login.clone()
     });
     result
 }

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -3,8 +3,12 @@ use std::collections::BTreeMap;
 use crate::publishers::fetch_owners_of_crates;
 use crate::{common::*, publishers::PublisherData};
 
-pub fn publishers(args: Vec<String>, max_age: std::time::Duration) -> Result<(), std::io::Error> {
-    let dependencies = sourced_dependencies(args);
+pub fn publishers(
+    metadata_args: Vec<String>,
+    diffable: bool,
+    max_age: std::time::Duration,
+) -> Result<(), std::io::Error> {
+    let dependencies = sourced_dependencies(metadata_args);
     complain_about_non_crates_io_crates(&dependencies);
     let (publisher_users, publisher_teams) = fetch_owners_of_crates(&dependencies, max_age)?;
 


### PR DESCRIPTION
Adds a `-d`, `--diffable` flag that produces output more friendly towards tools such as `diff` and `comm`.

WIP, only 2/3 of the subcommands are converted. I could use input on the basic direction.