### PR TITLE
Drop 'url' field since it's not present in the DB dumps

### DIFF
--- a/src/crates_cache.rs
+++ b/src/crates_cache.rs
@@ -300,7 +300,6 @@ impl CratesCache {
                 Some(PublisherData {
                     id: user.id,
                     avatar: user.gh_avatar.clone(),
-                    url: None,
                     login: user.gh_login.clone(),
                     name: user.name.clone(),
                     kind: PublisherKind::user,
@@ -322,7 +321,6 @@ impl CratesCache {
                 Some(PublisherData {
                     id: team.id,
                     avatar: team.avatar.clone(),
-                    url: None,
                     login: team.login.clone(),
                     name: team.name.clone(),
                     kind: PublisherKind::team,

--- a/src/publishers.rs
+++ b/src/publishers.rs
@@ -27,7 +27,9 @@ pub struct PublisherData {
     pub id: u64,
     pub login: String,
     pub kind: PublisherKind,
-    pub url: Option<String>,
+    // URL is disabled because it's present in API responses but not in DB dumps,
+    // so the output would vary inconsistent depending on data source
+    //pub url: Option<String>,
     /// Display name. It is NOT guaranteed to be unique!
     pub name: Option<String>,
     /// Avatar image URL

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -32,7 +32,13 @@ pub fn publishers(args: Vec<String>, max_age: std::time::Duration) -> Result<(),
         let map_for_display = sort_transposed_map_for_display(team_to_crate_map);
         for (i, (team, crates)) in map_for_display.iter().enumerate() {
             let crate_list = comma_separated_list(&crates);
-            println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
+            if team.login.starts_with("github:") {
+                if let Some(org) = team.login.split(':').nth(1) {
+                    println!(" {}. \"{}\" (https://github.com/{}) via crates: {}", i + 1, &team.login, org, crate_list);
+                }
+            } else {
+                println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
+            }
         }
         println!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
     }

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -32,16 +32,17 @@ pub fn publishers(args: Vec<String>, max_age: std::time::Duration) -> Result<(),
         let map_for_display = sort_transposed_map_for_display(team_to_crate_map);
         for (i, (team, crates)) in map_for_display.iter().enumerate() {
             let crate_list = comma_separated_list(&crates);
-            if team.login.starts_with("github:") {
-                if let Some(org) = team.login.split(':').nth(1) {
-                    println!(
-                        " {}. \"{}\" (https://github.com/{}) via crates: {}",
-                        i + 1,
-                        &team.login,
-                        org,
-                        crate_list
-                    );
-                }
+            if let (true, Some(org)) = (
+                team.login.starts_with("github:"),
+                team.login.split(':').nth(1),
+            ) {
+                println!(
+                    " {}. \"{}\" (https://github.com/{}) via crates: {}",
+                    i + 1,
+                    &team.login,
+                    org,
+                    crate_list
+                );
             } else {
                 println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
             }

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -34,7 +34,13 @@ pub fn publishers(args: Vec<String>, max_age: std::time::Duration) -> Result<(),
             let crate_list = comma_separated_list(&crates);
             if team.login.starts_with("github:") {
                 if let Some(org) = team.login.split(':').nth(1) {
-                    println!(" {}. \"{}\" (https://github.com/{}) via crates: {}", i + 1, &team.login, org, crate_list);
+                    println!(
+                        " {}. \"{}\" (https://github.com/{}) via crates: {}",
+                        i + 1,
+                        &team.login,
+                        org,
+                        crate_list
+                    );
                 }
             } else {
                 println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);

--- a/src/subcommands/publishers.rs
+++ b/src/subcommands/publishers.rs
@@ -32,17 +32,7 @@ pub fn publishers(args: Vec<String>, max_age: std::time::Duration) -> Result<(),
         let map_for_display = sort_transposed_map_for_display(team_to_crate_map);
         for (i, (team, crates)) in map_for_display.iter().enumerate() {
             let crate_list = comma_separated_list(&crates);
-            if let Some(url) = &team.url {
-                println!(
-                    " {}. \"{}\" ({}) via crates: {}",
-                    i + 1,
-                    &team.login,
-                    url,
-                    crate_list
-                );
-            } else {
-                println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
-            }
+            println!(" {}. \"{}\" via crates: {}", i + 1, &team.login, crate_list);
         }
         println!("\nGithub teams are black boxes. It's impossible to get the member list without explicit permission.");
     }


### PR DESCRIPTION
`url` field is not present in the crates.io database dumps. It was only used for linking to Github orgs, so emulate that by parsing the data - hopefully in a failsafe way.

I consider this a release blocker because it also removes the field from the JSON output.