### PR TITLE
"update" subcommand and tests in general

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,13 @@ fn validate_args(args: Args) -> Result<ValidatedArgs, std::io::Error> {
                 format!("Unrecognized argument: {}", args.free[0]),
             ));
         }
+        //FIXME Should maybe cause subcommands::help(String::from("update")) to be called instead of eprint_help() in main
+        if args.command == "update" && (args.diffable || !args.metadata_args.is_empty()) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Update subcommand doesn't allow --diffable or metadata arguments"),
+            ));
+        }
         match args.command.as_str() {
             "publishers" => {
                 return Ok(ValidatedArgs::Publishers {


### PR DESCRIPTION
Resolves #70. It prints an error and then prints the general error help, but I feel like it should print the contents of `cargo supply-chain help update` instead (showing that it doesn't accept them), but that requires some restructuring of the code - possibly custom Error class altogether? I'd also like to add some tests, but not sure where to put them.