### PR TITLE
Prettier cli code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bpaf"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba13e5c0d9314ca471d8b10e2fbf245b3f83a904cfb0a9d50f12b72971b12cd"
+checksum = "5444c3016c57b548d9e45e85cddaaa987a48449148f464ba4af854e95fb46a01"
 
 [[package]]
 name = "bstr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.30"
 indicatif = "0.16.0"
-bpaf = "0.3.0"
+bpaf = "0.3.2"
 
 [dev-dependencies]
 schemars = "0.8.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ pub(crate) enum CliArgs {
 
 /// Parses arguments provided on the command line.
 /// This function is generic to allow unit testing.
-pub(crate) fn parse_args<T: AsRef<OsStr>>(args: &[T]) -> Result<CliArgs, ParseFailure> {
+pub(crate) fn parse_args<T: AsRef<OsStr> + ?Sized>(args: &[&T]) -> Result<CliArgs, ParseFailure> {
     let args: Vec<&OsStr> = args.iter().map(|a| a.as_ref()).collect();
     let mut args: &[&OsStr] = &args;
     // This is the reason this function even exists:
@@ -45,7 +45,7 @@ pub(crate) fn parse_args<T: AsRef<OsStr>>(args: &[T]) -> Result<CliArgs, ParseFa
     args_parser().run_inner(Args::from(args))
 }
 
-fn args_parser() -> OptionParser<CliArgs> {
+pub(crate) fn args_parser() -> OptionParser<CliArgs> {
     let diffable = short('d')
         .long("diffable")
         .help("Make output more friendly towards tools such as `diff`")

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,25 +16,12 @@ mod crates_cache;
 mod publishers;
 mod subcommands;
 
-use std::{env::args_os, ffi::OsString};
-
-use bpaf::ParseFailure;
 use cli::CliArgs;
 use common::MetadataArgs;
 
 fn main() -> Result<(), std::io::Error> {
-    let raw_args: Vec<OsString> = args_os().skip(1).collect();
-    match cli::parse_args(&raw_args) {
-        Ok(args) => dispatch_command(args),
-        Err(ParseFailure::Stdout(msg)) => {
-            println!("{}", msg);
-            std::process::exit(0);
-        }
-        Err(ParseFailure::Stderr(msg)) => {
-            eprintln!("{}", msg);
-            std::process::exit(1);
-        }
-    }
+    let args = cli::args_parser().run();
+    dispatch_command(args)
 }
 
 fn dispatch_command(args: CliArgs) -> Result<(), std::io::Error> {


### PR DESCRIPTION
No user-facing changes. Takes advantage of `bpaf`'s new `cargo_helper` to simplify the code.