### PR TITLE
bpaf 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bpaf"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0001ae0a7a63663e9b2fbb7a1ba1baf092826a0c8cc43934a94d5f7da8a9f970"
+checksum = "d47cb29c6d11f3f9740f28c36bf9c0019a6c4f34fa4ac049e05f82be96b005ff"
 
 [[package]]
 name = "bstr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.30"
 indicatif = "0.17.0"
-bpaf = "0.4.3"
+bpaf = "0.5.0"
 anyhow = "1.0.28"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,13 +166,9 @@ See 'cargo supply-chain <command> --help' for more information on a specific com
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsStr;
-
     use super::*;
 
-    fn parse_args<T: AsRef<OsStr> + ?Sized>(args: &[&T]) -> Result<CliArgs, ParseFailure> {
-        let args: Vec<&OsStr> = args.iter().map(|a| a.as_ref()).collect();
-        let args: &[&OsStr] = &args;
+    fn parse_args(args: &[&str]) -> Result<CliArgs, ParseFailure> {
         args_parser().run_inner(Args::from(args))
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,46 +83,43 @@ fn meta_args() -> impl Parser<MetadataArgs> {
 }
 
 pub(crate) fn args_parser() -> OptionParser<CliArgs> {
-    let publishers = {
-        let publishers_long = "\
+    let publishers = construct!(CliArgs::Publishers { args(), meta_args() })
+        .to_options()
+        .descr("Lists all crates.io publishers in the dependency graph and owned crates for each")
+        .header(
+            "\
 If a local cache created by 'update' subcommand is present and up to date,
-it will be used. Otherwise live data will be fetched from the crates.io API.";
-        let publishers_short =
-            "Lists all crates.io publishers in the dependency graph and owned crates for each";
-        let parser = construct!(CliArgs::Publishers { args(), meta_args() })
-            .to_options()
-            .descr(publishers_short)
-            .header(publishers_long);
+it will be used. Otherwise live data will be fetched from the crates.io API.",
+        )
+        .command("publishers");
 
-        command("publishers", parser)
-    };
-
-    let crates = {
-        let parser = construct!(CliArgs::Crates { args(), meta_args() });
-        let crates_long = "\
+    let crates = (construct!(CliArgs::Crates { args(), meta_args() }))
+        .to_options()
+        .descr("List all crates in dependency graph and crates.io publishers for each")
+        .header(
+            "\
 If a local cache created by 'update' subcommand is present and up to date,
-it will be used. Otherwise live data will be fetched from the crates.io API.";
-        let crates_short = "List all crates in dependency graph and crates.io publishers for each";
-        let parser = parser.to_options().descr(crates_short).header(crates_long);
-        command("crates", parser)
-    };
+it will be used. Otherwise live data will be fetched from the crates.io API.",
+        )
+        .command("crates");
 
     let json = {
         let print_schema = long("print-schema")
             .help("Print JSON schema and exit")
             .req_flag(CliArgs::JsonSchema);
         let json = construct!(CliArgs::Json { args(), meta_args() });
-        let parser = (construct!([json, print_schema])).to_options().descr(
-            "\
+        (construct!([json, print_schema]))
+            .to_options()
+            .descr(
+                "\
 Detailed info on publishers of all crates in the dependency graph, in JSON
 
 The JSON schema is also available, use --print-schema to get it.
 
 If a local cache created by 'update' subcommand is present and up to date,
 it will be used. Otherwise live data will be fetched from the crates.io API.",
-        );
-
-        command("json", parser)
+            )
+            .command("json")
             .help("Like 'crates', but in JSON and with more fields for each publisher")
     };
 
@@ -138,9 +135,8 @@ a newer version will not be downloaded.
 Note that this downloads the entire crates.io database, which is hundreds of Mb of data!
 If you are on a metered connection, you should not be running the 'update' subcommand.
 Instead, rely on requests to the live API - they are slower, but use much less data.",
-        );
-
-    let update = command("update", update)
+        )
+        .command("update")
         .help("Download the latest daily dump from crates.io to speed up other commands");
 
     cargo_helper(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,28 +84,27 @@ fn meta_args() -> impl Parser<MetadataArgs> {
 
 pub(crate) fn args_parser() -> OptionParser<CliArgs> {
     let publishers = {
-        let publishers_long =
-            "Lists all crates.io publishers in the dependency graph and owned crates for each
-
+        let publishers_long = "\
 If a local cache created by 'update' subcommand is present and up to date,
 it will be used. Otherwise live data will be fetched from the crates.io API.";
-        let publishers_short = "List all crates.io publishers in the depedency graph";
+        let publishers_short =
+            "Lists all crates.io publishers in the dependency graph and owned crates for each";
         let parser = construct!(CliArgs::Publishers { args(), meta_args() })
             .to_options()
-            .descr(publishers_long);
+            .descr(publishers_short)
+            .header(publishers_long);
 
-        command("publishers", parser).help(publishers_short)
+        command("publishers", parser)
     };
 
     let crates = {
         let parser = construct!(CliArgs::Crates { args(), meta_args() });
-        let crates_long = "Lists all crates in dependency graph and crates.io publishers for each
-
+        let crates_long = "\
 If a local cache created by 'update' subcommand is present and up to date,
 it will be used. Otherwise live data will be fetched from the crates.io API.";
         let crates_short = "List all crates in dependency graph and crates.io publishers for each";
-        let parser = parser.to_options().descr(crates_long);
-        command("crates", parser).help(crates_short)
+        let parser = parser.to_options().descr(crates_short).header(crates_long);
+        command("crates", parser)
     };
 
     let json = {
@@ -113,11 +112,9 @@ it will be used. Otherwise live data will be fetched from the crates.io API.";
             .help("Print JSON schema and exit")
             .req_flag(CliArgs::JsonSchema);
         let json = construct!(CliArgs::Json { args(), meta_args() });
-
-        let parser = construct!([json, print_schema]);
-
-        let parser = parser.to_options().descr(
-            "Detailed info on publishers of all crates in the dependency graph, in JSON
+        let parser = (construct!([json, print_schema])).to_options().descr(
+            "\
+Detailed info on publishers of all crates in the dependency graph, in JSON
 
 The JSON schema is also available, use --print-schema to get it.
 
@@ -132,7 +129,8 @@ it will be used. Otherwise live data will be fetched from the crates.io API.",
     let update = construct!(CliArgs::Update { cache_max_age() })
         .to_options()
         .descr(
-            "Download the latest daily dump from crates.io to speed up other commands
+            "\
+Download the latest daily dump from crates.io to speed up other commands
 
 If the local cache is already younger than specified in '--cache-max-age' option,
 a newer version will not be downloaded.
@@ -145,20 +143,18 @@ Instead, rely on requests to the live API - they are slower, but use much less d
     let update = command("update", update)
         .help("Download the latest daily dump from crates.io to speed up other commands");
 
-    let parser = cargo_helper(
+    cargo_helper(
         "supply-chain",
         construct!([publishers, crates, json, update]),
-    );
-
-    parser
-        .to_options()
-        .version(env!("CARGO_PKG_VERSION"))
-        .descr("Gather author, contributor and publisher data on crates in your dependency graph")
-        .footer(
-            "\
+    )
+    .to_options()
+    .version(env!("CARGO_PKG_VERSION"))
+    .descr("Gather author, contributor and publisher data on crates in your dependency graph")
+    .footer(
+        "\
 Most commands also accept flags controlling the features, targets, etc.
 See 'cargo supply-chain <command> --help' for more information on a specific command.",
-        )
+    )
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,9 +23,7 @@ pub(crate) enum CliArgs {
         args: QueryCommandArgs,
         meta_args: MetadataArgs,
     },
-    JsonSchema {
-        print_schema: (),
-    },
+    JsonSchema,
     Update {
         cache_max_age: Duration,
     },
@@ -113,11 +111,10 @@ it will be used. Otherwise live data will be fetched from the crates.io API.";
     let json = {
         let print_schema = long("print-schema")
             .help("Print JSON schema and exit")
-            .req_flag(());
+            .req_flag(CliArgs::JsonSchema);
         let json = construct!(CliArgs::Json { args(), meta_args() });
-        let jschema = construct!(CliArgs::JsonSchema { print_schema });
 
-        let parser = construct!([json, jschema]);
+        let parser = construct!([json, print_schema]);
 
         let parser = parser.to_options().descr(
             "Detailed info on publishers of all crates in the dependency graph, in JSON

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn dispatch_command(args: CliArgs) -> Result<(), anyhow::Error> {
         CliArgs::Json { args, meta_args } => {
             subcommands::json(meta_args, args.diffable, args.cache_max_age)?
         }
-        CliArgs::JsonSchema { print_schema: () } => {
+        CliArgs::JsonSchema => {
             subcommands::print_schema()?;
         }
         CliArgs::Update { cache_max_age } => subcommands::update(cache_max_age)?,


### PR DESCRIPTION
This should reduce the executable size a bit and make things to look a bit prettier.

You might want to drop the last two commits - "split the descriptions" one technically changes the help output a bit. Alternatively you can change all the commands have similar changes: previous version had two strings for each command: _short and _long, and short one is shared for help description inside the inner command and for command help one level up. New version reuses `descr` field from the inner parser so if it matches the short description - you can use the variable only once.

Tests are still passing, also thanks to them found a small bug in the new version :)

