### PR TITLE
Migrate to bpaf v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bpaf"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47cb29c6d11f3f9740f28c36bf9c0019a6c4f34fa4ac049e05f82be96b005ff"
+checksum = "42efc66e688b6433a6763382c4edda86483ec063e5f18e929c31f70d69c29c02"
 
 [[package]]
 name = "bstr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.30"
 indicatif = "0.17.0"
-bpaf = "0.5.0"
+bpaf = "0.6.0"
 anyhow = "1.0.28"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ The cache will be considered valid while younger than specified.
 The format is a human readable duration such as `1w` or `1d 6h`.
 If not specified, the cache is considered valid for 48 hours.",
         )
-        .argument("AGE")
+        .argument::<String>("AGE")
         .parse(|text| humantime::parse_duration(&text))
         .fallback(Duration::from_secs(48 * 3600))
 }
@@ -62,15 +62,15 @@ fn meta_args() -> impl Parser<MetadataArgs> {
         .switch();
     let features = long("features")
         .help("Space or comma separated list of features to activate")
-        .argument("FEATURES")
+        .argument::<String>("FEATURES")
         .optional();
     let target = long("target")
         .help("Only include dependencies matching the given target-triple")
-        .argument("TRIPLE")
+        .argument::<String>("TRIPLE")
         .optional();
     let manifest_path = long("manifest-path")
         .help("Path to Cargo.toml")
-        .argument_os("PATH")
+        .argument::<PathBuf>("PATH")
         .map(PathBuf::from)
         .optional();
     construct!(MetadataArgs {


### PR DESCRIPTION
@pacak are the turbofishes on `argument` mandatory now, or is there a simpler way to do this that I'm not seeing?

If this is how it's intended to be used, then I prefer v0.5 API.