### PR TITLE
Convert `output` to `serde_json::Value` before printing

### DIFF
--- a/src/subcommands/json.rs
+++ b/src/subcommands/json.rs
@@ -56,7 +56,8 @@ pub fn json(
     let stdout = std::io::stdout();
     let handle = stdout.lock();
     if diffable {
-        serde_json::to_writer_pretty(handle, &output)?;
+        let value = serde_json::to_value(&output)?;
+        serde_json::to_writer_pretty(handle, &value)?;
     } else {
         serde_json::to_writer(handle, &output)?;
     }


### PR DESCRIPTION
This change causes map keys to be ordered alphabetically. An example appears below.

I'm not 100% sure of the reason for the difference. I suspect that without converting to a value, `serde_json` uses Serde machinery to traverse struct fields (e.g., [`PublisherData`](https://github.com/rust-secure-code/cargo-supply-chain/blob/ede428b811170eae5c7d093d06e371e7d02229fa/src/publishers.rs#L28-L39)) in the order in which they are declared. Whereas, a `serde_json::Objects`'s keys are [always ordered alphabetically](https://github.com/serde-rs/json/blob/42ab31feacef82f1cb4c11892b43fe2d89208cd7/src/map.rs#L34).

I would be happy to add a test. I would just need some direction on where an how to add it.

---

Without the change:
```shell
$ cargo supply-chain json --diffable
...
    "xdg": [
      {
        "id": 654,
        "login": "whitequark",
        "kind": "user",
        "name": "whitequark",
        "avatar": "https://avatars1.githubusercontent.com/u/54771?v=4"
      }
    ]
...
```
With the change:
```shell
$ cargo run -- supply-chain json --diffable
...
    "xdg": [
      {
        "avatar": "https://avatars1.githubusercontent.com/u/54771?v=4",
        "id": 654,
        "kind": "user",
        "login": "whitequark",
        "name": "whitequark"
      }
    ]
...
```